### PR TITLE
Add link to pkgdown website in logo

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -10,7 +10,7 @@ editor_options:
 knitr::opts_chunk$set(fig.path = "man/figures/", echo = TRUE)
 ```
 
-# pdindicatoR <img src="man/figures/logo.png" align="right" height="139" alt="" />
+# pdindicatoR <a href="https://b-cubed-eu.github.io/pdindicatoR/"><img src="man/figures/logo.png" align="right" height="139" alt="pdindicatoR website" /></a>
 
 <!-- badges: start -->
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# pdindicatoR <img src="man/figures/logo.png" align="right" height="139" alt="" />
+# pdindicatoR <a href="https://b-cubed-eu.github.io/pdindicatoR/"><img src="man/figures/logo.png" align="right" height="139" alt="pdindicatoR website" /></a>
 
 <!-- badges: start -->
 


### PR DESCRIPTION
This is a convention and renders better on the documentation website.